### PR TITLE
Some conversion warning suppressed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,7 @@ jerry_add_compile_flags(-fno-stack-protector)
 endif()
 
 if (USING_GCC OR USING_CLANG)
-  jerry_add_compile_warnings(all extra format-nonliteral init-self conversion sign-conversion format-security missing-declarations shadow strict-prototypes undef old-style-definition)
+  jerry_add_compile_warnings(all extra format-nonliteral init-self sign-conversion format-security missing-declarations shadow strict-prototypes undef old-style-definition)
   jerry_add_compile_flags(-Wno-stack-protector -Wno-attributes)
 endif()
 
@@ -227,7 +227,7 @@ endif()
 
 # TODO: Remove workaround for gcc 7 bug if the
 # fallthrough comment detection is fixed.
-if (USING_GCC AND CMAKE_C_COMPILER_VERSION VERSION_GREATER 7.0)
+if (USING_GCC)
   jerry_add_compile_flags(-Wno-implicit-fallthrough)
 endif()
 


### PR DESCRIPTION
The compilation of JerryScript with valid Nuttx and TizenRT headers
triggered many compilation warnings for int to bitfield conversions.
One of the reasons for this warning is usage of unlikely preprocessor
directives.

1. A conversion warnings were disabled for JerryScript. They cause many
   false negatives for int to bit filed conversions at older versions of
   GCC.
2. A flag Wno-implicit-fallthrough was enabled for all versions of GCC
   not just for version greater than 7.0.

JerryScript-DCO-1.0-Signed-off-by: Jaroslaw Pelczar j.pelczar@samsung.com