### PR TITLE
Revert "Nuttx compilation fix for ECMA_IS_VALUE_ERROR"

### DIFF
--- a/jerry-core/ecma/base/ecma-globals.h
+++ b/jerry-core/ecma/base/ecma-globals.h
@@ -199,7 +199,7 @@ typedef int32_t ecma_integer_value_t;
  * Checks whether the error flag is set.
  */
 #define ECMA_IS_VALUE_ERROR(value) \
-  ((value) & ECMA_VALUE_ERROR_FLAG ? true : false)
+  (unlikely ((value & ECMA_VALUE_ERROR_FLAG) != 0))
 
 /**
  * Representation for native external pointer


### PR DESCRIPTION
This reverts commit 87d92fd74ab3556ee76fe4bf99db77f962c11ee0.

IoT.js-DCO-1.0-Signed-off-by: Piotr Marcinkiewicz p.marcinkiew@samsung.com